### PR TITLE
Feature to set backup name 

### DIFF
--- a/src/BackupManager.php
+++ b/src/BackupManager.php
@@ -16,7 +16,6 @@ class BackupManager
     protected $fBackupName;
     protected $dBackupName;
     protected $fileVerifyName = 'backup-verify';
-
     /**
      * BackupManager constructor.
      */
@@ -51,7 +50,8 @@ class BackupManager
                 'size_raw' => $file['size'],
                 'size' => $this->formatSizeUnits($file['size']),
                 'type' => $file['basename'][0] === 'd' ? 'Database' : 'Files',
-                'date' => date('M d Y', $this->getFileTimeStamp($file))
+                'date' => date('M d Y', $this->getFileTimeStamp($file)),
+                'time' => date('H:m:s', $this->getFileTimeStamp($file))
             ];
         }
 
@@ -395,5 +395,13 @@ class BackupManager
         $power = $size > 0 ? floor(log($size, 1024)) : 0;
 
         return number_format($size / (1024 ** $power), 2, '.', ',') . ' ' . $units[$power];
+    }
+    /**
+     * Set backup name
+     */
+    public function setBackupName( $name )
+    {
+        $this->fBackupName = "f_$name.tar";
+        $this->dBackupName = "d_$name.gz";
     }
 }

--- a/src/BackupManager.php
+++ b/src/BackupManager.php
@@ -23,7 +23,7 @@ class BackupManager
     {
         $this->disk = config('backupmanager.backups.disk');
         $this->backupPath = config('backupmanager.backups.backup_path') . DIRECTORY_SEPARATOR;
-        $this->backupSuffix = strtolower(config('backupmanager.backups.backup_file_date_suffix'));
+        $this->backupSuffix = strtolower(date('M-d-Y-h:i:sa'));
         $this->fBackupName = "f_$this->backupSuffix.tar";
         $this->dBackupName = "d_$this->backupSuffix.gz";
 

--- a/src/BackupManager.php
+++ b/src/BackupManager.php
@@ -51,7 +51,7 @@ class BackupManager
                 'size' => $this->formatSizeUnits($file['size']),
                 'type' => $file['basename'][0] === 'd' ? 'Database' : 'Files',
                 'date' => date('M d Y', $this->getFileTimeStamp($file)),
-                'time' => date('H:m:s', $this->getFileTimeStamp($file))
+                'time' => date('h:i:sa', $this->getFileTimeStamp($file))
             ];
         }
 

--- a/src/BackupManager.php
+++ b/src/BackupManager.php
@@ -188,13 +188,14 @@ class BackupManager
 
             $connection = [
                 'host' => config('database.connections.mysql.host'),
+                'port' => config('database.connections.mysql.port'),
                 'database' => config('database.connections.mysql.database'),
                 'username' => config('database.connections.mysql.username'),
                 'password' => config('database.connections.mysql.password'),
             ];
 
             $tableOptions = '';
-            $connectionOptions = "--user={$connection['username']} --password=\"{$connection['password']}\" --host={$connection['host']} {$connection['database']} ";
+            $connectionOptions = "--user={$connection['username']} --password=\"{$connection['password']}\" --host={$connection['host']} --port={$connection['port']} {$connection['database']} ";
 
             // https://mariadb.com/kb/en/library/mysqldump/
             $options = [
@@ -276,6 +277,7 @@ class BackupManager
 
                 $connection = [
                     'host' => config('database.connections.mysql.host'),
+                    'port' => config('database.connections.mysql.port'),
                     'database' => config('database.connections.mysql.database'),
                     'username' => config('database.connections.mysql.username'),
                     'password' => config('database.connections.mysql.password'),
@@ -287,7 +289,7 @@ class BackupManager
                     $connectionOptions .= " -p\"{$connection['password']}\" ";
                 }
 
-                $connectionOptions .= " -h {$connection['host']} {$connection['database']} ";
+                $connectionOptions .= " -h {$connection['host']} --port={$connection['port']} {$connection['database']} ";
 
                 //$command = "$cd gunzip < $this->fBackupName | mysql $connectionOptions";
                 $command = 'cd ' . str_replace('\\', '/',

--- a/src/Config/config.php
+++ b/src/Config/config.php
@@ -58,7 +58,7 @@ return [
         'backup_path' => 'backups',
 
         // backup files name suffix
-        'backup_file_date_suffix' => date('M-d-Y'),
+        'backup_file_date_suffix' => date('M-d-Y-h:m:s'),
 
         // define number of days old backup files will be deleted before new backup
         'delete_old_backup_days' => 10

--- a/src/Http/Controllers/BackupManagerController.php
+++ b/src/Http/Controllers/BackupManagerController.php
@@ -2,11 +2,13 @@
 
 namespace Sarfraznawaz2005\BackupManager\Http\Controllers;
 
-use Illuminate\Routing\Controller as BaseController;
 use Log;
-use Sarfraznawaz2005\BackupManager\Facades\BackupManager;
 use Session;
 use Storage;
+use Illuminate\Routing\Controller as BaseController;
+use Sarfraznawaz2005\BackupManager\Facades\BackupManager;
+use Sarfraznawaz2005\BackupManager\Http\Requests\CreateBackupRequest;
+
 
 class BackupManagerController extends BaseController
 {
@@ -26,9 +28,13 @@ class BackupManagerController extends BaseController
         return view('backupmanager::index', compact('title', 'backups'));
     }
 
-    public function createBackup()
+    public function createBackup(CreateBackupRequest $request)
     {
         $messages = [];
+
+        // Set name
+        if ($request->backupName != '')
+            BackupManager::setBackupName($request->backupName);
 
         // create backups
         $result = BackupManager::createBackup();
@@ -183,4 +189,5 @@ class BackupManagerController extends BaseController
 
         return response()->download($file);
     }
+
 }

--- a/src/Http/Requests/CreateBackupRequest.php
+++ b/src/Http/Requests/CreateBackupRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sarfraznawaz2005\BackupManager\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateBackupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        // Regex: no space
+        return [
+            'backupName' => ['nullable' ,'string', 'max: 25', 'alpha_dash']
+        ];
+    }
+}

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -3,7 +3,8 @@
 Route::group(
     [
         'namespace' => 'Sarfraznawaz2005\BackupManager\Http\Controllers',
-        'prefix' => config('backupmanager.route', 'backupmanager')
+        'prefix' => config('backupmanager.route', 'backupmanager'),
+        'middleware' => 'web'
     ],
     function () {
         // list backups

--- a/src/Views/index.blade.php
+++ b/src/Views/index.blade.php
@@ -5,6 +5,7 @@
 @section('header')
     <form action="{{route('backupmanager_create')}}" method="post" id="frmNew">
         {{ csrf_field() }}
+        <input type="text" name="backupName">
         <button type="submit" class="btn btn-warning btn-sm"><i class="fa fa-plus"></i> Create New Backup</button>
     </form>
 @endsection
@@ -20,6 +21,7 @@
                 <th style="text-align: center;" width="1">#</th>
                 <th>Name</th>
                 <th>Date</th>
+                <th>Time</th>
                 <th>Size</th>
                 <th style="text-align: center;">Health</th>
                 <th style="text-align: center;">Type</th>
@@ -34,6 +36,7 @@
                     <td style="text-align: center;">{{++$index}}</td>
                     <td>{{$backup['name']}}</td>
                     <td class="date">{{$backup['date']}}</td>
+                    <td>{{$backup['time']}}</td>
                     <td>{{$backup['size']}}</td>
                     <td style="text-align: center;">
                         <?php

--- a/src/Views/layout/layout.blade.php
+++ b/src/Views/layout/layout.blade.php
@@ -154,7 +154,11 @@
                     </p>
                 @endforeach
             @endif
-
+            @error('backupName')
+            <span class="alert alert-danger">
+                {{ $message }}
+            </span>
+            @enderror
             @yield('content')
         </div>
 


### PR DESCRIPTION
**Feature**
Adding the ability to set a custom name for a backup either through the facade or the gui
I have added an input to the backup manager page to set the name or left empty to use the default one set in config.

**Example**
public function index()
{
    	BackupManager::setBackupName('test');
    	BackupManager::createBackup();
    	return view('welcome');
}
